### PR TITLE
feat #7 : 도메인 설계

### DIFF
--- a/src/main/java/com/renew/sw/mentoring/domain/comment/model/CommentStatus.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/comment/model/CommentStatus.java
@@ -1,0 +1,20 @@
+package com.renew.sw.mentoring.domain.comment.model;
+
+public enum CommentStatus {
+    /**
+     * 활성화 상태
+     */
+    ACTIVE,
+    /**
+     * 작성자에 의해 수정된 상태
+     */
+    EDITED,
+    /**
+     * 작성자에 의해 삭제된 상태
+     */
+    DELETED,
+    /**
+     * 운영자에 의해 삭제된 상태
+     */
+    DELETED_BY_ADMIN
+}

--- a/src/main/java/com/renew/sw/mentoring/domain/comment/model/entity/Comment.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/comment/model/entity/Comment.java
@@ -1,0 +1,46 @@
+package com.renew.sw.mentoring.domain.comment.model.entity;
+
+import com.renew.sw.mentoring.domain.comment.model.CommentStatus;
+import com.renew.sw.mentoring.domain.post.model.entity.Post;
+import com.renew.sw.mentoring.domain.user.model.entity.User;
+import com.renew.sw.mentoring.global.base.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@Getter
+@RequiredArgsConstructor
+public class Comment extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "comment_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Lob
+    private String content;
+
+    @Enumerated(EnumType.STRING)
+    private CommentStatus commentStatus;
+
+    @Builder
+    private Comment(@NotNull Post post,
+                    @NotNull User user,
+                    String content,
+                    CommentStatus commentStatus) {
+        this.post = post;
+        this.user = user;
+        this.content = content;
+        this.commentStatus = commentStatus;
+    }
+}

--- a/src/main/java/com/renew/sw/mentoring/domain/mission/model/MissionStatus.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/mission/model/MissionStatus.java
@@ -1,0 +1,7 @@
+package com.renew.sw.mentoring.domain.mission.model;
+
+public enum MissionStatus {
+    MAIN,
+
+    EVENT
+}

--- a/src/main/java/com/renew/sw/mentoring/domain/mission/model/entity/BonusMission.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/mission/model/entity/BonusMission.java
@@ -1,0 +1,45 @@
+package com.renew.sw.mentoring.domain.mission.model.entity;
+
+import com.renew.sw.mentoring.domain.mission.model.MissionStatus;
+import com.renew.sw.mentoring.domain.team.model.entity.Team;
+import com.renew.sw.mentoring.global.base.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Entity
+@Getter
+@RequiredArgsConstructor
+public class BonusMission extends BaseEntity{
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bonus_mission_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id")
+    private Mission mission;
+
+    @NotBlank
+    private String name;
+
+    @Lob
+    private String description;
+
+    @NotNull
+    private int point;
+
+    @Builder
+    private BonusMission(@NotNull Mission mission,
+                        @NotNull String name,
+                        String description,
+                        @NotNull int point) {
+        this.mission = mission;
+        this.name = name;
+        this.description = description;
+        this.point = point;
+    }
+}

--- a/src/main/java/com/renew/sw/mentoring/domain/mission/model/entity/Mission.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/mission/model/entity/Mission.java
@@ -1,0 +1,53 @@
+package com.renew.sw.mentoring.domain.mission.model.entity;
+
+import com.renew.sw.mentoring.domain.mission.model.MissionStatus;
+import com.renew.sw.mentoring.domain.post.model.entity.type.MissionBoard;
+import com.renew.sw.mentoring.global.base.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@RequiredArgsConstructor
+public class Mission extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "mission_id")
+    private Long id;
+
+    @NotBlank
+    private String name;
+
+    @Lob
+    private String description;
+
+    @NotNull
+    private int point;
+
+    @Enumerated(EnumType.STRING)
+    private MissionStatus missionStatus;
+
+    @OneToMany(mappedBy = "mission")
+    private List<BonusMission> bonusMissions = new ArrayList<>();
+
+    @OneToMany(mappedBy = "mission")
+    private List<MissionBoard> missionBoards = new ArrayList<>();
+
+    @Builder
+    private Mission(@NotNull String name,
+                    String description,
+                    @NotNull int point,
+                    MissionStatus missionStatus) {
+        this.name = name;
+        this.description = description;
+        this.point = point;
+        this.missionStatus = missionStatus;
+    }
+}

--- a/src/main/java/com/renew/sw/mentoring/domain/post/model/entity/Post.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/post/model/entity/Post.java
@@ -1,0 +1,52 @@
+package com.renew.sw.mentoring.domain.post.model.entity;
+
+
+import com.renew.sw.mentoring.domain.comment.model.entity.Comment;
+import com.renew.sw.mentoring.domain.user.model.entity.User;
+import com.renew.sw.mentoring.global.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@DynamicUpdate
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "type")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public abstract class Post extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private String title;
+
+    @Lob
+    private String body;
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<PostFile> files = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<PostImage> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "post", cascade = CascadeType.PERSIST, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    protected Post(User user, String title, String body) {
+        this.user = user;
+        this.title = title;
+        this.body = body;
+    }
+}

--- a/src/main/java/com/renew/sw/mentoring/domain/post/model/entity/PostFile.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/post/model/entity/PostFile.java
@@ -1,0 +1,42 @@
+package com.renew.sw.mentoring.domain.post.model.entity;
+
+import com.renew.sw.mentoring.global.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostFile extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_file_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    private String fileName;
+
+    private String fileUrl;
+
+    @Builder
+    private PostFile(String fileName, String fileUrl) {
+        this.fileName = fileName;
+        this.fileUrl = fileUrl;
+    }
+
+    public void changePost(Post post) {
+        if (this.post != null) {
+            this.post.getFiles().remove(this);
+        }
+
+        this.post = post;
+        this.post.getFiles().add(this);
+    }
+}

--- a/src/main/java/com/renew/sw/mentoring/domain/post/model/entity/PostImage.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/post/model/entity/PostImage.java
@@ -1,0 +1,42 @@
+package com.renew.sw.mentoring.domain.post.model.entity;
+
+import com.renew.sw.mentoring.global.base.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PostImage extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "post_file_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "post_id")
+    private Post post;
+
+    private String fileName;
+
+    private String fileUrl;
+
+    @Builder
+    private PostImage(String fileName, String fileUrl) {
+        this.fileName = fileName;
+        this.fileUrl = fileUrl;
+    }
+
+    public void changePost(Post post) {
+        if (this.post != null) {
+            this.post.getImages().remove(this);
+        }
+
+        this.post = post;
+        this.post.getImages().add(this);
+    }
+}

--- a/src/main/java/com/renew/sw/mentoring/domain/post/model/entity/RegisterStatus.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/post/model/entity/RegisterStatus.java
@@ -1,0 +1,23 @@
+package com.renew.sw.mentoring.domain.post.model.entity;
+
+public enum RegisterStatus {
+    /**
+     * 진행중
+     */
+    IN_PROGRESS,
+
+    /**
+     * 승인됨
+     */
+    ACCEPTED,
+
+    /**
+     * 거절됨
+     */
+    REJECTED,
+
+    /**
+     * 삭제됨
+     */
+    DELETED
+}

--- a/src/main/java/com/renew/sw/mentoring/domain/post/model/entity/type/MissionBoard.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/post/model/entity/type/MissionBoard.java
@@ -1,0 +1,33 @@
+package com.renew.sw.mentoring.domain.post.model.entity.type;
+
+import com.renew.sw.mentoring.domain.mission.model.entity.Mission;
+import com.renew.sw.mentoring.domain.post.model.entity.Post;
+import com.renew.sw.mentoring.domain.post.model.entity.RegisterStatus;
+import com.renew.sw.mentoring.domain.user.model.entity.User;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MissionBoard extends Post {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id")
+    private Mission mission;
+
+    @Enumerated(EnumType.STRING)
+    private RegisterStatus registerStatus;
+
+    @Builder
+    private MissionBoard(@NotNull User user,
+                         @NotNull String title,
+                         @NotNull String body,
+                         @NotNull Mission mission,
+                         @NotNull RegisterStatus registerStatus) {
+        super(user, title, body);
+        this.mission = mission;
+        this.registerStatus = registerStatus;
+    }
+}

--- a/src/main/java/com/renew/sw/mentoring/domain/post/model/entity/type/Notice.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/post/model/entity/type/Notice.java
@@ -1,0 +1,22 @@
+package com.renew.sw.mentoring.domain.post.model.entity.type;
+
+import com.renew.sw.mentoring.domain.post.model.entity.Post;
+import com.renew.sw.mentoring.domain.user.model.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.validation.constraints.NotNull;
+import lombok.*;
+
+/**
+ * 공지 게시글
+ */
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Notice extends Post {
+    @Builder
+    private Notice(@NotNull User user,
+                   @NotNull String title,
+                   @NotNull String body) {
+        super(user, title, body);
+    }
+}

--- a/src/main/java/com/renew/sw/mentoring/domain/team/model/entity/Team.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/team/model/entity/Team.java
@@ -1,0 +1,40 @@
+package com.renew.sw.mentoring.domain.team.model.entity;
+
+import com.renew.sw.mentoring.domain.user.model.entity.User;
+import com.renew.sw.mentoring.global.base.BaseEntity;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@RequiredArgsConstructor
+public class Team extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "team_id")
+    private Long id;
+
+    @NotBlank
+    private String teamName;
+
+    @NotNull
+    private int score;
+
+    @OneToMany(mappedBy = "team")
+    private List<User> users = new ArrayList<>();
+
+    @Builder
+    private Team(@NotNull String teamName,
+                @NotNull int score) {
+        this.teamName = teamName;
+        this.score = score;
+    }
+}

--- a/src/main/java/com/renew/sw/mentoring/domain/user/model/entity/User.java
+++ b/src/main/java/com/renew/sw/mentoring/domain/user/model/entity/User.java
@@ -1,6 +1,8 @@
 package com.renew.sw.mentoring.domain.user.model.entity;
 
+import com.renew.sw.mentoring.domain.team.model.entity.Team;
 import com.renew.sw.mentoring.domain.user.model.UserRole;
+import com.renew.sw.mentoring.global.base.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -17,15 +19,16 @@ import static lombok.AccessLevel.PROTECTED;
         @Index(name = "idx_student_id", columnList = "student_id"),
         @Index(name = "idx_nickname", columnList = "nickname")
 })
-public class User {
+public class User extends BaseEntity {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "user_id")
     private Long id;
 
-    // TODO : Team Entity 추가 후 주석 해제
-//    private Team team;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "team_id")
+    private Team team;
 
     @NotBlank
     @Column
@@ -46,11 +49,13 @@ public class User {
     private String nickname;
 
     @Builder
-    public User(@NotNull String studentId,
+    private User(@NotNull Team team,
+                @NotNull String studentId,
                 @NotNull String password,
                 @NotNull String name,
                 @NotNull String nickname,
                 UserRole userRole) {
+        this.team = team;
         this.studentId = studentId;
         this.password = password;
         this.name = name;

--- a/src/main/java/com/renew/sw/mentoring/global/base/BaseEntity.java
+++ b/src/main/java/com/renew/sw/mentoring/global/base/BaseEntity.java
@@ -1,0 +1,25 @@
+package com.renew.sw.mentoring.global.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@EntityListeners(AuditingEntityListener.class)
+@MappedSuperclass
+@Getter
+public abstract class BaseEntity {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime lastModifiedAt;
+
+    public abstract Long getId();
+}


### PR DESCRIPTION
* 기존 User 엔티티에 새로 생성한 Team 엔티티와의 연관 관계 추가
* Notice, MissionBoard 엔티티들은 Post 엔티티와 상속 관계로 구현
* 나머지 엔티티들 생성 후, 연관 관계 매핑 수행